### PR TITLE
Add basic bill splitting calculator with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# split_alculator_test
-テスト用割り勘計算（Next.js）
+# split_calculator_test
+
+Simple utility for calculating how to split a bill among a group.
+
+## Usage
+
+Run the script directly with Node (totals should be provided in the smallest currency unit such as cents):
+
+```bash
+node splitCalculator.js 1000 3
+# => [334,333,333]
+```
+
+## Development
+
+Install dependencies (none needed) and run tests with:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "split_alculator_test",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/splitCalculator.js
+++ b/splitCalculator.js
@@ -1,0 +1,19 @@
+export function splitBill(total, people) {
+  if (!Number.isFinite(total) || total < 0) {
+    throw new Error('Total must be a non-negative number');
+  }
+  if (!Number.isInteger(people) || people <= 0) {
+    throw new Error('People must be a positive integer');
+  }
+  const baseShare = Math.floor(total / people);
+  const remainder = total % people;
+  return Array.from({ length: people }, (_, idx) =>
+    baseShare + (idx < remainder ? 1 : 0)
+  );
+}
+
+// If executed directly, run a simple example
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [total, people] = process.argv.slice(2).map(Number);
+  console.log(splitBill(total, people));
+}

--- a/splitCalculator.test.js
+++ b/splitCalculator.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { splitBill } from './splitCalculator.js';
+
+test('splits evenly', () => {
+  assert.deepEqual(splitBill(1000, 4), [250, 250, 250, 250]);
+});
+
+test('distributes remainder without overcharging', () => {
+  assert.deepEqual(splitBill(1000, 3), [334, 333, 333]);
+});
+
+test('throws on invalid people count', () => {
+  assert.throws(() => splitBill(1000, 0), /positive integer/);
+});
+
+test('throws on negative totals', () => {
+  assert.throws(() => splitBill(-100, 3), /non-negative/);
+});


### PR DESCRIPTION
## Summary
- enforce non-negative totals and positive integer participant counts
- distribute bill remainder without overcharging
- document and test new input validation and distribution logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c04b5ea3848324aea9fb5766c0913c